### PR TITLE
support of oslc 2.0 API used by RTC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.ibm.maximo</groupId>
 	<artifactId>maximo-restclient</artifactId>
-	<version>1.0.5-ea</version>
+	<version>1.0.6-ea</version>
 
 	<name>maximo-rest-client</name>
 	<description>The Maximo REST client library provides a set of driver API's which can be consumed by an JAVA based web component that would like to interface with a Maximo instance</description>

--- a/src/main/java/com/ibm/maximo/oslc/MaximoConnector.java
+++ b/src/main/java/com/ibm/maximo/oslc/MaximoConnector.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -329,6 +330,11 @@ public class MaximoConnector {
 		HttpURLConnection con = (HttpURLConnection) httpURL
 				.openConnection();
 		con = this.setMethod(con, "GET");
+		if (headers == null) {
+			headers = this.options.getHeaders();
+		} else {
+			headers.putAll(this.options.getHeaders());
+		}
 		if (headers!=null && !headers.isEmpty() ) {
 			con = this.setHeaders(con, headers);
 		}

--- a/src/main/java/com/ibm/maximo/oslc/Options.java
+++ b/src/main/java/com/ibm/maximo/oslc/Options.java
@@ -10,6 +10,9 @@
 
 package com.ibm.maximo.oslc;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * 
  * {@code Options} is served for {@code MaximoConnector}.
@@ -47,6 +50,7 @@ public class Options {
 	private String apiContext = "oslc";
 	private String appURI = null;
 	private String tenantcode = "00";
+	private Map<String,Object> headers = new HashMap<>();
 	
 	public Options host(String host)
 	{
@@ -116,6 +120,11 @@ public class Options {
 	public Options apikey(String apikey)
 	{
 		this.apikey = apikey;
+		return this;
+	}
+	
+	public Options header(String key, Object value) {
+		this.headers.put(key, value);
 		return this;
 	}
 	
@@ -248,5 +257,9 @@ public class Options {
 		//if(mt == true) strb.append("?&_tenantcode="+tenantcode);
 		this.publicURI = strb.toString();
 		return this.publicURI;
+	}
+	
+	public Map<String,Object> getHeaders() {
+		return this.headers;
 	}
 }

--- a/src/main/java/com/ibm/maximo/oslc/ResourceSet.java
+++ b/src/main/java/com/ibm/maximo/oslc/ResourceSet.java
@@ -341,6 +341,8 @@ public class ResourceSet {
 		}
 		if (this.jsonObject.containsKey("rdfs:member")) {
 			this.jsonArray = (JsonArray) this.jsonObject.get("rdfs:member");
+		} else if (this.jsonObject.containsKey("oslc:results")) {
+			this.jsonArray = (JsonArray) this.jsonObject.get("oslc:results");
 		} else {
 			this.jsonArray = (JsonArray) this.jsonObject.get("member");
 		}
@@ -357,6 +359,8 @@ public class ResourceSet {
 		this.jsonObject = this.mc.get(this.appURI);
 		if (this.jsonObject.containsKey("rdfs:member")) {
 			this.jsonArray = (JsonArray) this.jsonObject.get("rdfs:member");
+		} else if (this.jsonObject.containsKey("oslc:results")) {
+			this.jsonArray = (JsonArray) this.jsonObject.get("oslc:results");
 		} else {
 			this.jsonArray = (JsonArray) this.jsonObject.get("member");
 		}
@@ -385,10 +389,16 @@ public class ResourceSet {
 			} 
 			else if (this.jsonObject.containsKey("oslc:responseInfo")) 
 			{
-				if(this.jsonObject.getJsonObject("oslc:responseInfo").containsKey("oslc:nextPage"))
+				JsonObject jsonObjectResponseInfo = this.jsonObject.getJsonObject("oslc:responseInfo");
+				
+				if(jsonObjectResponseInfo.containsKey("oslc:nextPage"))
 				{
-					this.appURI = this.jsonObject.getJsonObject("oslc:responseInfo")
-							.getJsonObject("oslc:nextPage").getString("rdf:resource");
+					if (jsonObjectResponseInfo.get("oslc:nextPage") instanceof JsonString) {
+						this.appURI = jsonObjectResponseInfo.getString("oslc:nextPage");
+					} else {
+						this.appURI = jsonObjectResponseInfo
+								.getJsonObject("oslc:nextPage").getString("rdf:resource");
+					}
 				}
 			}
 		}
@@ -399,12 +409,11 @@ public class ResourceSet {
 		}
 
 		this.jsonObject = this.mc.get(this.appURI);
-		if (this.jsonObject.containsKey("rdfs:member")) 
-		{
+		if (this.jsonObject.containsKey("rdfs:member")) {
 			this.jsonArray = (JsonArray) this.jsonObject.get("rdfs:member");
-		} 
-		else 
-		{
+		} else if (this.jsonObject.containsKey("oslc:results")) {
+			this.jsonArray = (JsonArray) this.jsonObject.get("oslc:results");
+		} else {
 			this.jsonArray = (JsonArray) this.jsonObject.get("member");
 		}
 		return this;
@@ -453,18 +462,41 @@ public class ResourceSet {
 					break;
 				}
 			}
-			if (pageno == 2) {
-				this.appURI = this.appURI.replace(
-						"pageno=" + String.valueOf(pageno), "");
+			if (isPageNo) {
+				if (pageno == 2) {
+					this.appURI = this.appURI.replace(
+							"pageno=" + String.valueOf(pageno), "");
+				} else {
+					this.appURI = this.appURI.replace(
+							"pageno=" + String.valueOf(pageno),
+							"pageno=" + String.valueOf(pageno - 1));
+				}
 			} else {
-				this.appURI = this.appURI.replace(
-						"pageno=" + String.valueOf(pageno),
-						"pageno=" + String.valueOf(pageno - 1));
+				boolean isStartIndex = false;
+				int startIndex = 0;
+				for (String str : strs) {
+					if (str.equals("_startIndex")) {
+						isStartIndex = true;
+					} else if (isStartIndex) {
+						startIndex = Integer.valueOf(str);
+						break;
+					}
+				}
+				if (startIndex <= pageSize) {
+					this.appURI = this.appURI.replace(
+							"_startIndex=" + String.valueOf(startIndex), "");
+				} else {
+					this.appURI = this.appURI.replace(
+							"_startIndex=" + String.valueOf(startIndex),
+							"_startIndex=" + String.valueOf(startIndex - pageSize));
+				}
 			}
 		}
 		this.jsonObject = this.mc.get(this.appURI);
 		if (this.jsonObject.containsKey("rdfs:member")) {
 			this.jsonArray = (JsonArray) this.jsonObject.get("rdfs:member");
+		} else if (this.jsonObject.containsKey("oslc:results")) {
+			this.jsonArray = (JsonArray) this.jsonObject.get("oslc:results");
 		} else {
 			this.jsonArray = (JsonArray) this.jsonObject.get("member");
 		}
@@ -485,6 +517,8 @@ public class ResourceSet {
 		this.jsonObject = this.mc.get(this.appURI);
 		if (this.jsonObject.containsKey("rdfs:member")) {
 			this.jsonArray = (JsonArray) this.jsonObject.get("rdfs:member");
+		} else if (this.jsonObject.containsKey("oslc:results")) {
+			this.jsonArray = (JsonArray) this.jsonObject.get("oslc:results");
 		} else {
 			this.jsonArray = (JsonArray) this.jsonObject.get("member");
 		}
@@ -819,6 +853,8 @@ public class ResourceSet {
 			int size = -1;
 			if (jo.containsKey("member")) {
 				size = jo.getJsonArray("member").size();
+			} else if (jo.containsKey("oslc:results")) {
+				size = jo.getJsonArray("oslc:results").size();
 			} else if (jo.containsKey("rdfs:member")) {
 				size = jo.getJsonArray("rdfs:member").size();
 			}
@@ -842,6 +878,8 @@ public class ResourceSet {
 		int size = -1;
 		if (this.jsonObject.containsKey("member")) {
 			size = this.jsonObject.getJsonArray("member").size();
+		} else if (this.jsonObject.containsKey("oslc:results")) {
+			size = this.jsonObject.getJsonArray("oslc:results").size();
 		} else if (this.jsonObject.containsKey("rdfs:member")) {
 			size = this.jsonObject.getJsonArray("rdfs:member").size();
 		}


### PR DESCRIPTION
Adds support to little differences in the OSLC 2.0 API of RTC regarding member elements attribute name (`oslc:results` vs `rdfs:member`) and pagination